### PR TITLE
HttpUnitUtils does not check the validity of input String

### DIFF
--- a/src/com/meterware/httpunit/HttpUnitUtils.java
+++ b/src/com/meterware/httpunit/HttpUnitUtils.java
@@ -76,6 +76,9 @@ public class HttpUnitUtils {
     public static String[] parseContentTypeHeader( String header ) {
         String[] result = new String[] { "text/plain", null };
         StringTokenizer st = new StringTokenizer( header, ";=" );
+        if (!st.hasMoreTokens()) {
+            throw new IllegalArgumentException( "Attempting to parse invalid header" );
+        }
         result[0] = st.nextToken();
         while (st.hasMoreTokens()) {
             String parameter = st.nextToken();

--- a/test/com/meterware/httpunit/EncodingTest.java
+++ b/test/com/meterware/httpunit/EncodingTest.java
@@ -81,6 +81,17 @@ public class EncodingTest extends HttpUnitTest {
     }
 
 
+    public void testParseEmptyHeader() throws Exception {
+        String invalidHeader = "";
+        try {
+            String result[]=HttpUnitUtils.parseContentTypeHeader(invalidHeader);
+            fail();
+        } catch (IllegalArgumentException iae) {
+            assertEquals( "header", "Attempting to parse invalid header" , iae.getMessage() );
+        }
+    }
+
+
     public void testSpecifiedEncoding() throws Exception {
         String hebrewTitle = "\u05d0\u05d1\u05d2\u05d3";
         String page = "<html><head><title>" + hebrewTitle + "</title></head>\n" +


### PR DESCRIPTION
HttpUnitUtils.java directly calls 'st.nextToken()' on 'java.util.StringTokenizer st' 
without checking if there are more tokens.  Because 'st' is built from the String header
that can be invalid (e.g., an empty String), this can lead to a runtime exception
without a useful error message.  This pull request adds an error message and a test.
